### PR TITLE
feat: 공연 목록 페이지 무한 스크롤 기능 추가

### DIFF
--- a/src/hooks/useScroll.ts
+++ b/src/hooks/useScroll.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+const useScroll = (): boolean => {
+  const [isEnd, setIsEnd] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsEnd(
+        document.documentElement.offsetHeight - 20 <=
+          window.innerHeight + document.documentElement.scrollTop
+      );
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  return isEnd;
+};
+
+export default useScroll;

--- a/src/pages/ConcertList/ConcertList.tsx
+++ b/src/pages/ConcertList/ConcertList.tsx
@@ -5,6 +5,7 @@ import DropdownSelect from "../../components/common/Dropdown/DropdownSelect";
 import ConcertCard from "../../components/common/ConcertCard/ConcertCard";
 import { ConcertProps } from "../../types/concertProps";
 import fetchConcertData from "./concertAPI";
+import useScroll from "../../hooks/useScroll";
 
 interface ConcertListItem {
   mt20id: string;
@@ -49,15 +50,31 @@ export default function ConcertList() {
   const [genreCode, setGenreCode] = useState<string>(""); // 전체장르(default)
   const [pfStateCode, setPfStateCode] = useState<string>("02"); // 공연중
   const [regionCode, setRegionCode] = useState<string>(""); // 전국
+  const [page, setPage] = useState(1);
+  const isEnd = useScroll();
 
   const getData = async () => {
-    const data = await fetchConcertData(genreCode, pfStateCode, regionCode);
-    setConcertList(data);
+    const data = await fetchConcertData(
+      genreCode,
+      pfStateCode,
+      regionCode,
+      page
+    );
+    setConcertList((prevData) => [...prevData, ...data]);
   };
 
+  // 공연 목록 정보 조회 요청
   useEffect(() => {
     getData();
-  }, [genreCode, pfStateCode, regionCode]);
+  }, [genreCode, pfStateCode, regionCode, page]);
+
+  // 화면 하단부 도착시 페이지 변경
+  useEffect(() => {
+    if (isEnd) {
+      setPage((prevPage) => prevPage + 1);
+    }
+    console.log(page);
+  }, [isEnd]);
 
   // onTabChanged 함수 정의
   const handleTabChange = (index: number) => {

--- a/src/pages/ConcertList/concertAPI.ts
+++ b/src/pages/ConcertList/concertAPI.ts
@@ -19,11 +19,12 @@ interface ConcertListItem {
 export default async function fetchConcertData(
   genreCode: string,
   pfStateCode: string,
-  regionCode: string
+  regionCode: string,
+  page: number
 ): Promise<ConcertListItem[]> {
   try {
     const response = await fetch(
-      `/openApi/restful/pblprfr?service=${process.env.REACT_APP_kopisKey}&stdate=20240901&eddate=20241230&rows=30&cpage=3&shcate=${genreCode}&prfstate=${pfStateCode}&signgucode=${regionCode}`
+      `/openApi/restful/pblprfr?service=${process.env.REACT_APP_kopisKey}&stdate=20240901&eddate=20241230&rows=30&cpage=${page}&shcate=${genreCode}&prfstate=${pfStateCode}&signgucode=${regionCode}`
     );
 
     if (!response.ok) {


### PR DESCRIPTION
- 공연 목록 조회시 처음 두번 렌더링되는 문제는 React.StrictMode 해제시 해결됩니다.
- 배포시에는 StrictMode 자동 해제되므로 끄지 않고 테스트시에만 주석처리해서 확인하는 방식으로 확인

- useScroll 커스텀훅 추가하였습니다.