### PR TITLE
refactor: 최근 검색어 리스트 컴포넌트 분리 및 스타일링

### DIFF
--- a/src/components/common/Tab/Tab.tsx
+++ b/src/components/common/Tab/Tab.tsx
@@ -6,6 +6,7 @@ interface TabProps {
   tabList?: (string | [string, number | null])[];
   withNumber?: boolean;
   onTabChanged?: (index: number) => void;
+  selectedIndex?: number; // selectedIndex 속성 추가
   children?: ReactNode;
 }
 
@@ -13,6 +14,7 @@ export default function Tab({
   tabList = [],
   withNumber = false,
   onTabChanged,
+  selectedIndex, // selectedIndex 추가
   children,
 }: TabProps) {
   const [activeList, setActiveList] = useState<boolean[]>([]);
@@ -29,17 +31,20 @@ export default function Tab({
       temp = (tabList as string[]).map((item) => [item, null]);
     }
 
-    setActiveList(new Array(temp.length).fill(false).fill(true, 0, 1));
     setTabTitleList(temp);
-  }, [tabList]);
+
+    // selectedIndex가 존재 하면 해당 인덱스에 값이 있도록 함
+    const initialIndex = selectedIndex !== undefined ? selectedIndex : 0;
+
+    setActiveList(
+      new Array(temp.length)
+        .fill(false)
+        .fill(true, initialIndex, initialIndex + 1)
+    );
+  }, [tabList, selectedIndex]);
 
   const onClick = (index: number) => {
     setActiveList((prev) => prev.map((_, i) => i === index));
-    // onTabChanged(index);
-
-    // 클릭한 요소
-    // const selectedItem = tabTitleList[index][0];
-    // console.log(selectedItem);
 
     // 부모 컴포넌트로 선택된 탭 정보 전달
     if (onTabChanged) {

--- a/src/pages/Search/RecentSearchList.module.scss
+++ b/src/pages/Search/RecentSearchList.module.scss
@@ -1,0 +1,36 @@
+@import "../../styles/_variables";
+@import "../../styles/_mixin";
+
+.recentSearchList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.recentSearchItem {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0px;
+
+  button {
+    color: $black-light;
+  }
+  span {
+    color: $black-light;
+    font-size: $font-sm;
+    margin-right: 2px;
+  }
+}
+
+.searchInfo {
+  display: flex;
+  align-items: center;
+}
+
+.removeButton {
+  margin-left: 10px;
+  background: none;
+  border: none;
+  color: red;
+  cursor: pointer;
+}

--- a/src/pages/Search/RecentSearchList.tsx
+++ b/src/pages/Search/RecentSearchList.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import Button from "../../components/common/Button/Button";
+import styles from "./RecentSearchList.module.scss";
+import CloseIcon from "../../assets/svg/CloseIcon";
+
+type RecentSearch = {
+  query: string;
+  date: number;
+};
+
+interface RecentSearchListProps {
+  recentQueries: RecentSearch[];
+  onQueryClick: (keyword: string) => void;
+  onQueryRemove: (queryToRemove: string) => void;
+}
+
+function RecentSearchList({
+  recentQueries,
+  onQueryClick,
+  onQueryRemove,
+}: RecentSearchListProps) {
+  const formatDate = (timestamp: number): string => {
+    const date = new Date(timestamp);
+    const month = (date.getMonth() + 1).toString().padStart(2, "0");
+    const day = date.getDate().toString().padStart(2, "0");
+    return `${month}.${day}`;
+  };
+
+  return (
+    <div>
+      <h2 style={{ fontSize: "18px", margin: "36px 0 16px" }}>최근 검색어</h2>
+      <ul className={styles.recentSearchList}>
+        {recentQueries.map((item) => (
+          <li key={item.query} className={styles.recentSearchItem}>
+            <Button
+              label={item.query}
+              onClick={() => onQueryClick(item.query)}
+            />
+            <div className={styles.searchInfo}>
+              <span>{formatDate(item.date)}</span>
+              <Button
+                label=''
+                onClick={() => onQueryRemove(item.query)}
+                iconOnly={<CloseIcon size='20' />}
+              />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default RecentSearchList;

--- a/src/pages/Search/Search.module.scss
+++ b/src/pages/Search/Search.module.scss
@@ -7,6 +7,9 @@
   row-gap: 8px;
   column-gap: 12px;
   margin: 24px 0;
+  padding: 24px 0;
+  border-top: 1px solid $line-lighter;
+  border-bottom: 1px solid $line-lighter;
 }
 
 .recommends_container {

--- a/src/pages/Search/Search.tsx
+++ b/src/pages/Search/Search.tsx
@@ -10,6 +10,7 @@ import { ConcertType } from "../../types/concertType";
 import { getConcertsFromFirebase } from "../../api/firebase/concertAPI";
 import PosterCard from "../../components/common/PosterCard/PosterCard";
 import { setQuery } from "../../slices/searchSlice";
+import RecentSearchList from "./RecentSearchList";
 
 export default function Search() {
   const navigate = useNavigate();
@@ -80,45 +81,19 @@ export default function Search() {
     localStorage.setItem("recentQueries", JSON.stringify(updatedQueries));
   };
 
-  // 날짜 포맷팅 함수
-  const formatDate = (timestamp: number) => {
-    const date = new Date(timestamp);
-    const month = (date.getMonth() + 1).toString().padStart(2, "0");
-    const day = date.getDate().toString().padStart(2, "0");
-    return `${month}.${day}`;
-  };
-
   return (
     <div>
       {query ? (
         <SearchResult />
       ) : (
         <>
-          <div>
-            <h2>최근 검색어</h2>
-            <ul>
-              {recentQueries.map((item) => (
-                <li
-                  key={item.query}
-                  style={{ display: "flex", justifyContent: "space-between" }}
-                >
-                  <Button
-                    label={item.query}
-                    onClick={() => handleRecentQueryClick(item.query)}
-                  />
-                  <div>
-                    <span>{formatDate(item.date)}</span>
-                    <button
-                      type='button'
-                      onClick={() => removeQuery(item.query)}
-                    >
-                      삭제
-                    </button>
-                  </div>
-                </li>
-              ))}
-            </ul>
-          </div>
+          {recentQueries.length !== 0 ? (
+            <RecentSearchList
+              recentQueries={recentQueries}
+              onQueryClick={handleRecentQueryClick}
+              onQueryRemove={removeQuery}
+            />
+          ) : null}
           <div className={styles.category_nav}>
             {Object.entries(genreMap).map(([genre, code]) => {
               // 제외할 장르의 코드
@@ -141,7 +116,7 @@ export default function Search() {
             })}
           </div>
           <div>
-            <h2>추천 콘텐츠</h2>
+            <h2 style={{ fontSize: "18px" }}>추천 콘텐츠</h2>
             <ul className={styles.recommends_container}>
               {recommends?.map((item) => (
                 <li key={item.concertId}>

--- a/src/pages/Search/Search.tsx
+++ b/src/pages/Search/Search.tsx
@@ -41,14 +41,22 @@ export default function Search() {
         })
       );
 
-      setRecommends(fbConcerts);
+      // 북마크 수로 내림차순 정렬 후, 상위 6개 선택
+      const sortedConcerts = fbConcerts
+        .sort(
+          (a, b) =>
+            (b.bookmarkedBy?.length || 0) - (a.bookmarkedBy?.length || 0)
+        )
+        .slice(0, 6);
+
+      // 상위 6개의 콘서트를 랜덤으로 섞기
+      const shuffledConcerts = sortedConcerts.sort(() => Math.random() - 0.5);
+
+      setRecommends(shuffledConcerts);
     };
+
     getdata();
   }, []);
-
-  useEffect(() => {
-    // console.log("🚀 ~ recommends:", recommends);
-  }, [recommends]); // recommends가 변경될 때마다 실행
 
   // 최근 검색어 가져오기
   useEffect(() => {

--- a/src/utils/constants/genreData.ts
+++ b/src/utils/constants/genreData.ts
@@ -11,6 +11,19 @@ export const genreList = [
   "기타",
 ];
 
+export const genreCodeList = [
+  "", // 전체
+  "GGGA", // 뮤지컬
+  "AAAA", // 연극
+  "CCCC", // 국악
+  "CCCA", // 클래식
+  "CCCD", // 대중음악
+  "BBBC", // 서양/한국무용
+  "EEEB", // 서커스/마술
+  "BBBE", // 대중무용
+  "EEEA", // 기타
+];
+
 export const genreMap: { [key: string]: string } = {
   뮤지컬: "GGGA",
   연극: "AAAA",


### PR DESCRIPTION
- 최근 검색어 리스트를 별도 컴포넌트로 분리
- 최근 검색어 리스트 스타일링 적용
- 공연 목록에서 URL의 genre에 따라 선택된 탭 동기화 기능 추가
- 추천 콘텐츠 북마크 순 상위 6개 공연을 랜덤 순서로 표시