### PR TITLE
Issue#178

### DIFF
--- a/src/components/common/Button/Button.module.scss
+++ b/src/components/common/Button/Button.module.scss
@@ -41,6 +41,12 @@
   background-color: $danger;
 }
 
+.danger_line {
+  color: $danger;
+  border-color: $danger;
+  background-color: $white;
+}
+
 .primary_line {
   color: $primary;
   border-color: $primary;

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -12,6 +12,7 @@ interface ButtonProps {
     | "primary_line"
     | "primary_line_light"
     | "danger"
+    | "danger_line"
     | "black"
     | "black_line"
     | "underlined"

--- a/src/components/common/LikeToggle/LikeToggle.module.scss
+++ b/src/components/common/LikeToggle/LikeToggle.module.scss
@@ -1,0 +1,19 @@
+@import "../../../styles/_variables";
+@import "../../../styles/_mixin";
+
+.btn {
+  display: flex;
+  gap: 4px;
+  justify-content: center;
+  align-items: center;
+  padding: 8px;
+  border: 1px solid transparent;
+  border-radius: 100px;
+  background-color: transparent;
+  cursor: pointer;
+  white-space: nowrap;
+  line-height: $font-height-lg;
+  &:disabled {
+    opacity: 0.4;
+  }
+}

--- a/src/components/common/LikeToggle/LikeToggle.tsx
+++ b/src/components/common/LikeToggle/LikeToggle.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import toast from "react-hot-toast";
 import styles from "./LikeToggle.module.scss";
 import LikeIcon from "../../../assets/svg/LikeIcon";
 import useToggle from "../../../hooks/useToggle";
@@ -26,7 +27,10 @@ export default function LikeToggle({
       type='button'
       className={`${styles.btn} text_danger`}
       disabled={disabled}
-      onClick={onToggle}
+      onClick={() => {
+        onToggle();
+        toast("좋아요 기능 개발중입니다.");
+      }}
     >
       <LikeIcon size={size === "md" ? "24" : "20"} active={isActive} />
       <span className='sr_only'>좋아요</span>

--- a/src/components/common/LikeToggle/LikeToggle.tsx
+++ b/src/components/common/LikeToggle/LikeToggle.tsx
@@ -29,7 +29,9 @@ export default function LikeToggle({
       disabled={disabled}
       onClick={() => {
         onToggle();
-        toast("좋아요 기능 개발중입니다.");
+        toast(
+          `좋아요 기능은 현재 개발 중입니다. \n이용에 불편을 드려 죄송합니다.`
+        );
       }}
     >
       <LikeIcon size={size === "md" ? "24" : "20"} active={isActive} />

--- a/src/components/common/LikeToggle/LikeToggle.tsx
+++ b/src/components/common/LikeToggle/LikeToggle.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import styles from "./Button.module.scss";
+import styles from "./LikeToggle.module.scss";
 import LikeIcon from "../../../assets/svg/LikeIcon";
 import useToggle from "../../../hooks/useToggle";
 
-interface LikeButtonProps {
+interface LikeToggleProps {
   likeCount?: number;
   size?: "sm" | "md";
   active?: boolean;
@@ -11,13 +11,13 @@ interface LikeButtonProps {
   // onClick?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
-export default function LikeButton({
+export default function LikeToggle({
   likeCount,
   size = "md",
   active = false,
   disabled = false,
   // onClick = () => {},
-}: LikeButtonProps) {
+}: LikeToggleProps) {
   const { isActive, onToggle } = useToggle(active);
   // TODO: 버튼 눌렸을 때 추가기능, 숫자 늘어나기
 

--- a/src/components/common/ReviewBar/ReviewBar.tsx
+++ b/src/components/common/ReviewBar/ReviewBar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import LikeButton from "../Button/LikeButton";
+import LikeToggle from "../LikeToggle/LikeToggle";
 import styles from "./ReviewBar.module.scss";
 import { ReviewType } from "../../../types/reviewType";
 
@@ -11,12 +11,12 @@ export default function ReviewBar({ review }: ReviewBarProps) {
   useEffect(() => {
     // likedBy: String[] - userId 에서
     // 로그인된 내 아이디가 있는지 없는지 확인후
-    // LikeButton에 active 설정하는 로직
+    // LikeToggle에 active 설정하는 로직
   }, []);
 
   return (
     <div className={styles.container}>
-      <LikeButton likeCount={review?.likeCount} />
+      <LikeToggle likeCount={review?.likeCount} />
     </div>
   );
 }

--- a/src/components/common/ReviewCard/ReviewCard.tsx
+++ b/src/components/common/ReviewCard/ReviewCard.tsx
@@ -5,7 +5,7 @@ import { UserType, defaultUserType } from "../../../types/userType";
 import { ReviewPropType, defaultReviewType } from "../../../types/reviewType";
 import StarIcon from "../../../assets/svg/StarIcon";
 import LikeIcon from "../../../assets/svg/LikeIcon";
-import LikeButton from "../Button/LikeButton";
+import LikeToggle from "../LikeToggle/LikeToggle";
 import Avatar from "../Avatar/Avatar";
 
 interface ReviewCardProps extends UserType, ReviewPropType {
@@ -45,7 +45,7 @@ export default function ReviewCard({
             userId={userId}
             profileImage={profileImage}
           />
-          {page === "main" && <LikeButton size='sm' likeCount={likeCount} />}
+          {page === "main" && <LikeToggle size='sm' likeCount={likeCount} />}
         </div>
       ) : (
         <Link to={reviewLink}>

--- a/src/components/common/ReviewTitle/ReviewTitle.tsx
+++ b/src/components/common/ReviewTitle/ReviewTitle.tsx
@@ -97,14 +97,14 @@ export default function ReviewTitle({
         description='삭제된 후기는 되돌릴 수 없습니다. 그래도 계속 진행하시겠습니까?'
         onClose={closeModal}
       >
-        <Button label='취소' color='primary_line' onClick={closeModal} />
         <Button
           label='삭제'
-          color='primary'
+          color='danger_line'
           onClick={() => {
             setIsConfirmedDeletion(true);
           }}
         />
+        <Button label='취소' color='default' onClick={closeModal} />
       </Modal>
     </header>
   );

--- a/src/pages/Profile/Profile.module.scss
+++ b/src/pages/Profile/Profile.module.scss
@@ -28,4 +28,7 @@
   .wrapper_dropdown {
     margin-bottom: 20px;
   }
+  &.review_list {
+    padding-top: 0;
+  }
 }


### PR DESCRIPTION
- LikeButton -> LikeToggle로 컴포넌트 분리 (BookmarkToggle 처럼 토글 기능을 가지기 때문에 명칭 변경하여 분리했습니다)
- LikeToggle 클릭시 토스트 알림 추가 (개발중이라는 내용)
- ReviewCard 간격을 main, concert_detail 기준에 맞추어 profile 페이지에서도 조정 - padding-top
- 후기삭제 팝업 스타일 변경 
  - 실행(삭제)가 취소보다 먼저 오도록 순서변경
  - 긍/부정 의미가 나뉘는 컬러 사용 (삭제와 같은 의미는 danger 컬러 사용하도록, 취소는 default 사용하도록 서비스 전체 스타일과 맞춤)

fixes #178