### PR TITLE
fix: 예매링크가 없을 때 예매하러가기 버튼이 안보이도록 변경

### DIFF
--- a/src/pages/ConcertDetail/ConcertDetail.tsx
+++ b/src/pages/ConcertDetail/ConcertDetail.tsx
@@ -289,13 +289,16 @@ export default function ConcertDetail() {
                 <span className='divider' />
                 {concertDetail.prfage}
               </p>
-              <Button
-                className={styles.booking_button}
-                size='sm'
-                color='default'
-                label='예매하러 가기'
-                onClick={openReservationModal}
-              />
+              {concertDetail.relates &&
+              concertDetail.relates.relate.length > 0 ? (
+                <Button
+                  className={styles.booking_button}
+                  size='sm'
+                  color='default'
+                  label='예매하러 가기'
+                  onClick={openReservationModal}
+                />
+              ) : null}
             </div>
           </div>
         </div>


### PR DESCRIPTION
### 이슈 설명
- 예매 정보가 없는 공연에서도 "예매하러 가기" 버튼이 표시되는 문제가 있었습니다.
- 사용자가 클릭 시 불필요한 모달이 열리며 사용자 경험을 저하시켰습니다.

### 해결 방안
- relates.relate.length > 0 조건을 추가하여 예매 정보가 존재할 때만 버튼을 렌더링하도록 변경하였습니다.

### 주요 변경 사항
- concertDetail.relates && concertDetail.relates.relate.length > 0 ?로 조건부 렌더링을 적용하였습니다.
- 버튼이 필요하지 않은 경우 렌더링되지 않도록 하였습니다.

### 테스트 내용
- 예매 정보가 있는 공연에서 "예매하러 가기" 버튼이 정상적으로 표시됨을 확인하였습니다.
- 예매 정보가 없는 공연에서는 버튼이 나타나지 않음을 확인하였습니다.