### PR TITLE
input에 라벨 태그 추가 및 ESLint 설정 변경

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,6 +32,12 @@
     "no-unused-vars": "off",
     "prefer-destructuring": "off",
     "react-hooks/exhaustive-deps": "off",
+    "jsx-a11y/label-has-associated-control": [
+      2,
+      {
+        "some": ["nesting", "id"],
+      },
+    ],
   },
   "settings": {
     "import/resolver": {

--- a/src/components/common/CalendarInput/CalendarInput.tsx
+++ b/src/components/common/CalendarInput/CalendarInput.tsx
@@ -44,7 +44,11 @@ export default function CalendarInput({
       onClick={handleClick}
       onKeyDown={handleClick}
     >
+      <label htmlFor='calendar-input' className='sr_only'>
+        calendar-input
+      </label>
       <input
+        id='calendar-input'
         ref={inputRef}
         className={`${styles.calendarInput} ${isEmptyDate ? styles.emptyDate : ""}`}
         type='date'

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -28,11 +28,20 @@ export default function Input({
   icon = undefined,
   fullWidth = false,
 }: InputProps) {
+  // ID 생성
+  const inputId = `input-${label.replace(/\s+/g, "-").toLowerCase()}`;
   return (
     <div className={`${styles.container} ${fullWidth ? styles.full : ""}`}>
+      {/* 접근성을 위해 label 태그 추가 */}
+      {label && (
+        <label htmlFor={inputId} className='sr_only'>
+          {label}
+        </label>
+      )}
       {label && <p className={styles.label}>{label}</p>}
       <div className={styles.input_icon_container}>
         <input
+          id={inputId} // label과 연결 하기 위해 추가함
           type={type}
           name={name}
           className={styles.input}

--- a/src/components/common/SearchInput/SearchInput.tsx
+++ b/src/components/common/SearchInput/SearchInput.tsx
@@ -63,7 +63,11 @@ export default function SearchInput({
       <span className={styles.icon_container}>
         <SearchIcon />
       </span>
+      <label htmlFor='search-input' className='sr_only'>
+        search-input
+      </label>
       <input
+        id='search-input'
         value={inputValue}
         type='text'
         className={styles.input}

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -79,6 +79,7 @@ export default function Login() {
           <h2 className='sr_only'>로그인</h2>
           <form className={styles.form} onSubmit={handleLogin}>
             <Input
+              name='email'
               value={email}
               onChange={onEmailChange}
               error={!!emailError}
@@ -87,6 +88,7 @@ export default function Login() {
               placeholder={placeholder.email}
             />
             <Input
+              name='password'
               type='password'
               value={password}
               onChange={onPasswordChange}


### PR DESCRIPTION
### 이슈 설명
- input 컴포넌트에 label 태그가 없어 스크린 리더 사용자가 입력 필드의 목적을 이해하기 어려웠습니다.

### 해결 방안
- label 태그를 추가하여 입력 필드와 연관된 설명을 제공.

### 주요 변경 사항
- ESLint 설정 파일 (.eslintrc) 변경
- "jsx-a11y/label-has-associated-control" 규칙 추가.
- 라벨과 연관된 입력 필드가 존재하는지 검증하도록 some: ["nesting", "id"] 옵션 적용.
- 둘중에 한가지 옵션으로만 라벨을 적용하면 되도록 허용함.

### 컴포넌트 수정
1. CalendarInput 컴포넌트:
- label 태그 추가 (htmlFor='calendar-input').
2. Input 컴포넌트:
- 동적으로 생성된 id와 label 연결.
- 접근성을 위한 label 태그 추가 및 sr_only 클래스 적용.
3. SearchInput 컴포넌트:
- label 태그 추가 (htmlFor='search-input').

### 테스트 내용
- 컴포넌트별 라벨과 입력 필드 연결 테스트
- 스크린 리더에서 각 입력 필드의 목적이 정상적으로 읽히는지 확인.
- 화면 상에서는 label 태그가 표시되지 않으며 기존 UI와 동일하게 동작.
