### PR TITLE
Kopis API 공연 목록 조회를 Netlify 서버리스 함수로 전환

### DIFF
--- a/functions/getConcertList.js
+++ b/functions/getConcertList.js
@@ -1,0 +1,49 @@
+// functions/getConcertList.js
+// eslint-disable-next-line no-undef, @typescript-eslint/no-require-imports
+const axios = require("axios");
+
+// eslint-disable-next-line no-undef
+exports.handler = async function (event) {
+  const {
+    genreCode,
+    pfStateCode,
+    regionCode,
+    page,
+    keyword,
+    startDate,
+    endDate,
+  } = event.queryStringParameters;
+
+  // eslint-disable-next-line no-undef
+  const serviceKey = process.env.REACT_APP_kopisKey; // Netlify 환경변수에서 가져오기
+
+  try {
+    const { data } = await axios.get(
+      "https://www.kopis.or.kr/openApi/restful/pblprfr",
+      {
+        params: {
+          service: serviceKey,
+          stdate: startDate,
+          eddate: endDate,
+          rows: 5, // 임시
+          cpage: page,
+          shcate: genreCode,
+          prfstate: pfStateCode,
+          signgucode: regionCode,
+          shprfnm: keyword,
+        },
+      }
+    );
+
+    return {
+      statusCode: 200,
+      body: data, // XML 그대로 반환
+    };
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  } catch (error) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "Failed to fetch concert list" }),
+    };
+  }
+};

--- a/src/api/kopisAPI.ts
+++ b/src/api/kopisAPI.ts
@@ -34,27 +34,22 @@ export const fetchConcertList = async (
   endDate: string
 ): Promise<ConcertReturnType[]> => {
   try {
-    const { data } = await axios.get("", {
+    const { data } = await axios.get("/getConcertList", {
       params: {
-        service: process.env.REACT_APP_kopisKey,
-        stdate: startDate,
-        eddate: endDate,
-        rows: 5,
-        cpage: page,
-        shcate: genreCode,
-        prfstate: pfStateCode,
-        signgucode: regionCode,
-        shprfnm: keyword,
+        genreCode,
+        pfStateCode,
+        regionCode,
+        page,
+        keyword,
+        startDate,
+        endDate,
       },
     });
 
-    const parsedData = parseXml(data) as ConcertReturnType[];
-    const concertList = !parsedData ? [] : parsedData;
-    // console.log("🚀 ~ concertList:", concertList);
-    return concertList;
+    const concertList = parseXml(data) as ConcertReturnType[];
+    return concertList || [];
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
   } catch (error) {
-    // console.error("Error fetching data:", error);
     return [];
   }
 };


### PR DESCRIPTION
### 개요
Kopis API 상세 정보에 이어서 공연 목록 또한 프론트에서 직접 호출하던 방식을
Netlify 서버리스 함수로 대체했습니다.  
이로 인해 CORS 문제를 해결하고, 프론트에서 공연 목록이 정상적으로 표시되도록 조치했습니다.

### 주요 변경 사항
1. **서버리스 함수 생성**
   - `/functions/getConcertList`를 만들어 Kopis API 요청을 대리 처리.
   - 기존 `getConcertDetail` 서버리스 함수도 함께 유지.

2. **프론트 로직 수정**
   - `kopisAPI.ts`에서 기존에 Kopis API로 직접 호출하던 함수를 서버리스 함수 호출로 변경.

3. **CORS 문제 해결**
   - 로컬 및 배포 환경에서 공연 목록과 상세 정보를 정상적으로 불러올 수 있도록 조치.

### 참고 및 추후 작업
- 장르별 공연 리스트는 최근 공연 일부만 보여주도록 유지.
- 검색 화면에서는 1년 이상의 데이터를 조회해야 하므로, 추후 `rows` 값과 기간 설정 조정 필요.
- 현재 로직은 1년 전부터 오늘까지를 30일 단위로 나누어 각각 5개씩 요청하도록 임시 설정.
